### PR TITLE
Use $operatingsystemmajrelease instead of $lsbmajdistrelease

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -14,9 +14,17 @@ define memcached::instance (
 
   validate_re($port,'^112[0-9]{2}$')
 
+  # Newer versions of puppet use newer facts; use what we have
+  if $::lsbmajdistrelease {
+    $major_release = $::lsbmajdistrelease
+  }
+  else {
+    $major_release = $::operatingsystemmajrelease
+  }
+
   case $::operatingsystem {
     centos: {
-      if $::lsbmajdistrelease < 6 { fail("CentOS version 5 or lower not supported by this type.")}
+      if $major_release < 6 { fail("CentOS version 5 or lower not supported by this type.")}
       file { "/etc/sysconfig/memcached_${name}":
         ensure  => file,
         owner   => 'root',
@@ -34,7 +42,7 @@ define memcached::instance (
       }
     }
     ubuntu: {
-      if $::lsbmajdistrelease < 12 { fail("Ubuntu version 11.10 or lower not supported by this type.")}
+      if $major_release < 12 { fail("Ubuntu version 11.10 or lower not supported by this type.")}
       file { "/etc/memcached_${name}.conf":
         ensure  => file,
         owner   => 'root',


### PR DESCRIPTION
It seems that $lsbmajdistrelease is no longer a fact available in current puppet (3.4.2), at least on CentOS 6.5

This uses $operatingsystemmajrelease if it exists, or the other. 

Without this change you get the error

```
Error: undefined method `<' for :undef:Symbol at /tmp/vagrant-puppet-1/modules-0/memcached/manifests/instance.pp:19 on node xxx
Wrapped exception:
undefined method `<' for :undef:Symbol
Error: undefined method `<' for :undef:Symbol at /tmp/vagrant-puppet-1/modules-0/memcached/manifests/instance.pp:19 on node xxx
```
