### PR TITLE
Support fix in facter 2.2 to lsbmajdistrelease

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -42,7 +42,7 @@ define memcached::instance (
       }
     }
     ubuntu: {
-      if $major_release < 12 { fail("Ubuntu version 11.10 or lower not supported by this type.")}
+      if $major_release !~ /^1[234]/ { fail("Ubuntu version 11.10 or lower not supported by this type.")}
       file { "/etc/memcached_${name}.conf":
         ensure  => file,
         owner   => 'root',


### PR DESCRIPTION
Facter 2.2 fixed the meaning of lsbmajdistrelease under Ubuntu
(so that e.g. Ubuntu 14.04.1 has lsbmajdistrelease = 14.04 rather
than 14).

To accomodate this fix, this commit changes the version check
to use a regex. The regex is also pessimistic wrt to versions
beyond 2014, so this would require a change when tested against
Ubuntu 15.04+.
